### PR TITLE
feat: add seniority endpoint

### DIFF
--- a/backend/e2etests/seniority.test.js
+++ b/backend/e2etests/seniority.test.js
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+import request from "supertest";
+import dotenv from "dotenv";
+
+dotenv.config();
+const apiHost = process.env.API_HOST;
+const endpoint = "seniority";
+
+describe(`${endpoint}`, function () {
+  describe("GET", function () {
+    it("return a list of seniority", async function () {
+      return request(apiHost)
+        .get(endpoint)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          expect(JSON.stringify(res.body)).equal(
+            '["Entry-level","Mid-level","Senior","Above senior-level","Executive"]'
+          );
+        });
+    });
+  });
+});

--- a/backend/internal/handlers/seniority_handler.go
+++ b/backend/internal/handlers/seniority_handler.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-//GetSeniority handles user sign in
+//GetSeniority returns a list of seniority levels
 func GetSeniority(c *gin.Context) {
 	seniority := []string{
 		v1beta.SeniorityEntryLevel,

--- a/backend/internal/handlers/seniority_handler.go
+++ b/backend/internal/handlers/seniority_handler.go
@@ -1,0 +1,21 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+	"github.com/gin-gonic/gin"
+)
+
+//GetSeniority handles user sign in
+func GetSeniority(c *gin.Context) {
+	seniority := []string{
+		v1beta.SeniorityEntryLevel,
+		v1beta.SeniorityMidLevel,
+		v1beta.SenioritySenior,
+		v1beta.SeniorityAboveSenior,
+		v1beta.SeniorityExecutive,
+	}
+
+	c.JSON(http.StatusOK, seniority)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -14,6 +14,9 @@ func main() {
 	//Salaries
 	router.GET("/salaries", handlers.GetSalaries)
 
+	//Seniority
+	router.GET("/seniority", handlers.GetSeniority)
+
 	if err := router.Run(":7000"); err != nil {
 		return
 	}

--- a/backend/pkg/models/v1beta/salaries.go
+++ b/backend/pkg/models/v1beta/salaries.go
@@ -2,6 +2,15 @@ package v1beta
 
 import "time"
 
+const (
+	SeniorityIntern      = "Intern"
+	SeniorityEntryLevel  = "Entry-level"
+	SeniorityMidLevel    = "Mid-level"
+	SenioritySenior      = "Senior"
+	SeniorityAboveSenior = "Above senior-level"
+	SeniorityExecutive   = "Executive"
+)
+
 //Salary defines the salary structure
 type Salary struct {
 	Title  string `json:"title" gorm:"column:title"`


### PR DESCRIPTION
This pull request add a seniority endpoint

Steps to verify:
- move to the backend folder with cd ./backend
- run make start-postrges to run an initialized database
- run make run to launch the api
- then run the command curl -X GET --silent localhost:7000/seniority you should see something like this
```
["Entry-level","Mid-level","Senior","Above senior-level","Executive"]
```
