### PR TITLE
feat: add get salaries by id endpoint

### DIFF
--- a/backend/e2etests/salaries.test.js
+++ b/backend/e2etests/salaries.test.js
@@ -20,5 +20,28 @@ describe(`${endpoint}`, function () {
           );
         });
     });
+
+    it("return a salary of id == 1", async function () {
+      return request(apiHost)
+        .get(`${endpoint}/1`)
+        .send()
+        .expect(200)
+        .expect("content-type", "application/json; charset=utf-8")
+        .then((res) => {
+          expect(JSON.stringify(res.body)).to.equal('{"id":1,"title":"Recruiting Manager","salary":1624669,"seniority":"Seniority","city":"Livefish","company_id":994,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"}');
+        });
+    });
+
+    it("return 404 for an non existing rating id", async function () {
+      return request(apiHost)
+        .get(`${endpoint}/1001`)
+        .send()
+        .expect(404)
+        .expect("content-type", "application/json; charset=utf-8")
+        .then((res) => {
+          expect(JSON.stringify(res.body)).contains('could not find salary');
+        });
+    });
+
   });
 });

--- a/backend/internal/handlers/salaries_handler.go
+++ b/backend/internal/handlers/salaries_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/elhmn/camerdevs/internal/server"
 	"github.com/gin-gonic/gin"
@@ -28,4 +29,34 @@ func GetSalaries(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, salaries)
+}
+
+//GetSalaryByID returns a salary by id
+func GetSalaryByID(c *gin.Context) {
+	//Initialize db client
+	db, err := server.GetDefaultDBClient()
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusInternalServerError,
+			gin.H{"error": "could not find salaries"})
+		return
+	}
+
+	idStr := c.Param("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusBadRequest,
+			gin.H{"error": "failed to parse parameters"})
+	}
+
+	salary, err := db.GetSalaryByID(id)
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusNotFound,
+			gin.H{"error": "could not find salary"})
+		return
+	}
+
+	c.JSON(http.StatusOK, salary)
 }

--- a/backend/internal/storage/salaries.go
+++ b/backend/internal/storage/salaries.go
@@ -12,3 +12,14 @@ func (db DB) GetSalaries() ([]v1beta.Salary, error) {
 
 	return salaries, nil
 }
+
+//GetSalaryByID get salary by `id`
+func (db DB) GetSalaryByID(id int64) (v1beta.Salary, error) {
+	salary := v1beta.Salary{}
+	ret := db.c.First(&salary, "id = ?", id)
+	if ret.Error != nil {
+		return salary, ret.Error
+	}
+
+	return salary, nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -13,6 +13,7 @@ func main() {
 
 	//Salaries
 	router.GET("/salaries", handlers.GetSalaries)
+	router.GET("/salaries/:id", handlers.GetSalaryByID)
 
 	//Companies
 	router.GET("/companies", handlers.GetCompanies)


### PR DESCRIPTION
This pull request add the GET `salaries/id` endpoint

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-postrges` to run an initialized database
- run  `make run` to launch the api
- then run the command `curl -X GET localhost:7000/salaries/1` you should see something like this

```
{"id":1,"title":"Recruiting Manager","salary":1624669,"seniority":"Seniority","city":"Livefish","company_id":994,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"}
```

