### PR TITLE
feat: add GET companies/:id endpoint

### DIFF
--- a/backend/e2etests/companies.test.js
+++ b/backend/e2etests/companies.test.js
@@ -15,8 +15,34 @@ describe(`${endpoint}`, function () {
         .expect(200)
         .expect("Content-Type", "application/json; charset=utf-8")
         .then((res) => {
-          expect(JSON.stringify(res.body[0])).equal('{"id":1,"name":"Brainverse","rating":2,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"}');
+          expect(JSON.stringify(res.body[0])).equal(
+            '{"id":1,"name":"Brainverse","rating":2,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"}'
+          );
         });
     });
+  });
+
+  it("return a company of id == 1", async function () {
+    return request(apiHost)
+      .get(`${endpoint}/1`)
+      .send()
+      .expect(200)
+      .expect("content-type", "application/json; charset=utf-8")
+      .then((res) => {
+        expect(JSON.stringify(res.body)).to.equal(
+          '{"id":1,"name":"Brainverse","rating":2,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"}'
+        );
+      });
+  });
+
+  it("return 404 for an non existing rating id", async function () {
+    return request(apiHost)
+      .get(`${endpoint}/1001`)
+      .send()
+      .expect(404)
+      .expect("content-type", "application/json; charset=utf-8")
+      .then((res) => {
+        expect(JSON.stringify(res.body)).contains("could not find company");
+      });
   });
 });

--- a/backend/internal/handlers/companies_handler.go
+++ b/backend/internal/handlers/companies_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/elhmn/camerdevs/internal/server"
 	"github.com/gin-gonic/gin"
@@ -28,4 +29,34 @@ func GetCompanies(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, companies)
+}
+
+//GetCompanyByID returns a company by id
+func GetCompanyByID(c *gin.Context) {
+	//Initialize db client
+	db, err := server.GetDefaultDBClient()
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusInternalServerError,
+			gin.H{"error": "could not find salaries"})
+		return
+	}
+
+	idStr := c.Param("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusBadRequest,
+			gin.H{"error": "failed to parse parameters"})
+	}
+
+	company, err := db.GetCompanyByID(id)
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusNotFound,
+			gin.H{"error": "could not find company"})
+		return
+	}
+
+	c.JSON(http.StatusOK, company)
 }

--- a/backend/internal/storage/companies.go
+++ b/backend/internal/storage/companies.go
@@ -12,3 +12,14 @@ func (db DB) GetCompanies() ([]v1beta.Company, error) {
 
 	return companies, nil
 }
+
+//GetCompanyByID get company by `id`
+func (db DB) GetCompanyByID(id int64) (v1beta.Company, error) {
+	company := v1beta.Company{}
+	ret := db.c.First(&company, "id = ?", id)
+	if ret.Error != nil {
+		return company, ret.Error
+	}
+
+	return company, nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -17,6 +17,7 @@ func main() {
 
 	//Companies
 	router.GET("/companies", handlers.GetCompanies)
+	router.GET("/companies/:id", handlers.GetCompanyByID)
 
 	//CompanyRatings
 	router.GET("/company-ratings", handlers.GetCompanyRatings)


### PR DESCRIPTION
This pull request add the GET `companies/id` endpoint

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-postrges` to run an initialized database
- run  `make run` to launch the api
- then run the command `curl -X GET localhost:7000/salaries/1` you should see something like this

```
{"id":1,"name":"Brainverse","rating":2,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"}
```

