### PR TITLE
Add get jobtitles endpoint

### DIFF
--- a/backend/docs/jobtitles.go
+++ b/backend/docs/jobtitles.go
@@ -1,0 +1,33 @@
+package docs
+
+// swagger:route GET /jobtitles jobtitles idOfCompanyWithoutID
+// Companies returns the list of jobtitles
+// responses:
+//   200: jobtitlesResponse
+//   400: badRequestResponse
+//   404: notFoundResponse
+
+// This text will appear as description of your response body.
+// swagger:response jobtitlesResponse
+type JobtitlesResponseWrapper struct {
+	// in:body
+	Body []string
+}
+
+// swagger:response badRequestResponse
+type JobtitlesBadRequestResponseWrapper struct {
+	// in:body
+	Body struct {
+		// Example: bad request
+		Error string `json:"error"`
+	}
+}
+
+// swagger:response notFoundResponse
+type JobtitlesNotFoundResponseWrapper struct {
+	// in:body
+	Body struct {
+		// Example: could not found
+		Error string `json:"error"`
+	}
+}

--- a/backend/e2etests/jobtitles.test.js
+++ b/backend/e2etests/jobtitles.test.js
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+import request from "supertest";
+import dotenv from "dotenv";
+
+dotenv.config();
+const apiHost = process.env.API_HOST;
+const endpoint = "jobtitles";
+
+describe(`${endpoint}`, function () {
+  describe("GET", function () {
+    it("return a list of jobtitles", async function () {
+      return request(apiHost)
+        .get(endpoint)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          expect(JSON.stringify(res.body[0])).equal(
+            '"Account Coordinator"'
+          );
+        });
+    });
+  });
+});

--- a/backend/internal/handlers/jobtitles_handler.go
+++ b/backend/internal/handlers/jobtitles_handler.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/elhmn/camerdevs/internal/server"
+	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+)
+
+//GetJobTitles return a list of job titles
+func GetJobTitles(c *gin.Context) {
+	//Initialize db client
+	db, err := server.GetDefaultDBClient()
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusInternalServerError,
+			gin.H{"error": "could not find job titles"})
+		return
+	}
+
+	titles, err := db.GetJobTitles()
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusInternalServerError,
+			gin.H{"error": "could not find job titles"})
+		return
+	}
+
+	c.JSON(http.StatusOK, titles)
+}

--- a/backend/internal/storage/jobtitles.go
+++ b/backend/internal/storage/jobtitles.go
@@ -1,0 +1,12 @@
+package storage
+
+//GetJobTitles get jobtitles
+func (db DB) GetJobTitles() ([]string, error) {
+	jobTitles := []string{}
+	ret := db.c.Table("salaries").Select("title").Distinct("title").Order("title").Find(&jobTitles)
+	if ret.Error != nil {
+		return jobTitles, ret.Error
+	}
+
+	return jobTitles, nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -29,6 +29,9 @@ func main() {
 	router.GET("/companies", handlers.GetCompanies)
 	router.GET("/companies/:id", handlers.GetCompanyByID)
 
+	//Jobtitles
+	router.GET("/jobtitles", handlers.GetJobTitles)
+
 	//CompanyRatings
 	router.GET("/company-ratings", handlers.GetCompanyRatings)
 	router.GET("/company-ratings/:id", handlers.GetCompanyRatingsByID)

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -203,6 +203,19 @@ paths:
           $ref: '#/responses/healthResponse'
       tags:
       - health
+  /jobtitles:
+    get:
+      description: Companies returns the list of jobtitles
+      operationId: idOfCompanyWithoutID
+      responses:
+        "200":
+          $ref: '#/responses/jobtitlesResponse'
+        "400":
+          $ref: '#/responses/badRequestResponse'
+        "404":
+          $ref: '#/responses/notFoundResponse'
+      tags:
+      - jobtitles
   /ratings:
     get:
       description: Ratings returns the list of ratings
@@ -311,6 +324,12 @@ responses:
           type: string
           x-go-name: Message
       type: object
+  jobtitlesResponse:
+    description: This text will appear as description of your response body.
+    schema:
+      items:
+        type: string
+      type: array
   notFoundResponse:
     description: ""
     schema:


### PR DESCRIPTION
This pull request add the GET `jobtitles` endpoint

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-postrges` to run an initialized database
- run  `make run` to launch the api
- then run the command `curl -X GET localhost:7000/jobtitles` you should see something like this

```
["Account Coordinator","Account Executive","Account Representative I","Account Representative II","Account Representative III","Account Representative IV","Accountant I","Accountant II","Accountant III","Accountant IV"
...
]
```