### PR TITLE
Add average-salary get endpoint

### DIFF
--- a/backend/docs/ratings.go
+++ b/backend/docs/ratings.go
@@ -18,11 +18,25 @@ import (
 //   400: badRequestResponse
 //   404: notFoundResponse
 
+// swagger:route GET /average-rating ratings idOfRatingWithoutID
+// Ratings returns the list of ratings
+// responses:
+//   200: averageRatingResponse
+//   400: badRequestResponse
+//   404: notFoundResponse
+
 // This text will appear as description of your response body.
 // swagger:response ratingsResponse
 type RatingsResponseWrapper struct {
 	// in:body
 	Body []v1beta.Rating
+}
+
+// This text will appear as description of your response body.
+// swagger:response averageRatingResponse
+type AverageRatingResponseWrapper struct {
+	// in:body
+	Body []v1beta.AverageRating
 }
 
 // swagger:response badRequestResponse

--- a/backend/e2etests/ratings.test.js
+++ b/backend/e2etests/ratings.test.js
@@ -45,3 +45,21 @@ describe(`${endpoint}`, function () {
 
   });
 });
+
+const endpoint2 = `average-rating`
+describe(`${endpoint2}`, function () {
+  describe("GET", function () {
+    it("return a list of ratings", async function () {
+      return request(apiHost)
+        .get(endpoint2)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          expect(JSON.stringify(res.body)).equal(
+            '{"rating":3,"salary":2543437}'
+          );
+        });
+    });
+  });
+});

--- a/backend/internal/handlers/ratings_handler.go
+++ b/backend/internal/handlers/ratings_handler.go
@@ -61,3 +61,25 @@ func GetRatingByID(c *gin.Context) {
 
 	c.JSON(http.StatusOK, rating)
 }
+
+//GetAverageRating handles /average-rating GET endpoint
+func GetAverageRating(c *gin.Context) {
+	//Initialize db client
+	db, err := server.GetDefaultDBClient()
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusInternalServerError,
+			gin.H{"error": "could not find ratings"})
+		return
+	}
+
+	rating, err := db.GetAverageRating()
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusInternalServerError,
+			gin.H{"error": "could not find average rating"})
+		return
+	}
+
+	c.JSON(http.StatusOK, rating)
+}

--- a/backend/internal/storage/ratings.go
+++ b/backend/internal/storage/ratings.go
@@ -2,6 +2,8 @@ package storage
 
 import (
 	"errors"
+	"math"
+	"strconv"
 
 	"github.com/elhmn/camerdevs/pkg/models/v1beta"
 	"gorm.io/gorm"
@@ -55,6 +57,29 @@ func (db DB) GetRatingByID(id int64) (v1beta.Rating, error) {
 
 	if rating.SalaryID == 0 {
 		return rating, errors.New("record not found")
+	}
+
+	return rating, nil
+}
+
+//GetAverageRating get average rating
+func (db DB) GetAverageRating() (v1beta.AverageRating, error) {
+	r := struct {
+		AVGRating string `gorm:"column:rating"`
+		AVGSalary string `gorm:"column:salary"`
+	}{}
+
+	ret := db.queryRatings().Select("AVG(s.salary) as salary, AVG(r.rating) as rating").Find(&r)
+	if ret.Error != nil {
+		return v1beta.AverageRating{}, ret.Error
+	}
+
+	vr, _ := strconv.ParseFloat(r.AVGRating, 64)
+	vs, _ := strconv.ParseFloat(r.AVGSalary, 64)
+
+	rating := v1beta.AverageRating{
+		Rating: int64(math.Round(vr)),
+		Salary: int64(math.Round(vs)),
 	}
 
 	return rating, nil

--- a/backend/main.go
+++ b/backend/main.go
@@ -36,6 +36,7 @@ func main() {
 	//Ratings
 	router.GET("/ratings", handlers.GetRatings)
 	router.GET("/ratings/:id", handlers.GetRatingByID)
+	router.GET("/average-rating", handlers.GetAverageRating)
 
 	//Seniority
 	router.GET("/seniority", handlers.GetSeniority)

--- a/backend/pkg/models/v1beta/ratings.go
+++ b/backend/pkg/models/v1beta/ratings.go
@@ -20,3 +20,9 @@ type Rating struct {
 	Country         string `json:"country" gorm:"column:country"`
 	City            string `json:"city" gorm:"column:city"`
 }
+
+//AverageRating defines the average rating structure
+type AverageRating struct {
+	Rating int64 `json:"rating" gorm:"column:rating"`
+	Salary int64 `json:"salary" gorm:"column:salary"`
+}

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -2,6 +2,19 @@ basePath: /
 consumes:
 - application/json; charset=utf-8
 definitions:
+  AverageRating:
+    description: AverageRating defines the average rating structure
+    properties:
+      rating:
+        format: int64
+        type: integer
+        x-go-name: Rating
+      salary:
+        format: int64
+        type: integer
+        x-go-name: Salary
+    type: object
+    x-go-package: github.com/elhmn/camerdevs/pkg/models/v1beta
   Company:
     description: Company defines the company structure
     properties:
@@ -121,6 +134,19 @@ info:
   title: Camerdevs API.
   version: 1.0.0
 paths:
+  /average-rating:
+    get:
+      description: Ratings returns the list of ratings
+      operationId: idOfRatingWithoutID
+      responses:
+        "200":
+          $ref: '#/responses/averageRatingResponse'
+        "400":
+          $ref: '#/responses/badRequestResponse'
+        "404":
+          $ref: '#/responses/notFoundResponse'
+      tags:
+      - ratings
   /companies:
     get:
       description: Companies returns the list of companies
@@ -281,6 +307,12 @@ paths:
 produces:
 - application/json
 responses:
+  averageRatingResponse:
+    description: This text will appear as description of your response body.
+    schema:
+      items:
+        $ref: '#/definitions/AverageRating'
+      type: array
   badRequestResponse:
     description: ""
     schema:


### PR DESCRIPTION
This pull request add the GET `average-salary` endpoint

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-postrges` to run an initialized database
- run  `make run` to launch the api
- then run the command `curl -X GET localhost:7000/average-rating` you should see something like this

```
{"rating":3,"salary":2543437}
```
