### PR TITLE
Sort list of companies

### DIFF
--- a/backend/e2etests/companies.test.js
+++ b/backend/e2etests/companies.test.js
@@ -16,7 +16,7 @@ describe(`${endpoint}`, function () {
         .expect("Content-Type", "application/json; charset=utf-8")
         .then((res) => {
           expect(JSON.stringify(res.body[0])).equal(
-            '{"id":1,"name":"Brainverse","rating":2,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"}'
+            '{"id":724,"name":"Abata","rating":5,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"}'
           );
         });
     });

--- a/backend/internal/storage/companies.go
+++ b/backend/internal/storage/companies.go
@@ -5,7 +5,7 @@ import "github.com/elhmn/camerdevs/pkg/models/v1beta"
 //GetCompanies get companies
 func (db DB) GetCompanies() ([]v1beta.Company, error) {
 	companies := []v1beta.Company{}
-	ret := db.c.Find(&companies)
+	ret := db.c.Table("companies").Order("name").Find(&companies)
 	if ret.Error != nil {
 		return companies, ret.Error
 	}


### PR DESCRIPTION
This pull request sorts GET `companies` endpoint response list

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-postrges` to run an initialized database
- run  `make run` to launch the api
- then run the command `curl -X GET localhost:7000/companies` you should see something like this

```
[{"id":724,"name":"Abata","rating":5,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"},{"id":512,"name":"Abatz","rating":1,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"},...
]
```