### PR TITLE
Add creation date to /ratings GET endpoint response

### DIFF
--- a/backend/docs/ratings.go
+++ b/backend/docs/ratings.go
@@ -11,7 +11,7 @@ import (
 //   400: badRequestResponse
 //   404: notFoundResponse
 
-// swagger:route GET /ratings/{id} ratings idOfRating
+// swagger:route GET /ratings/{salaryID} ratings idOfRating
 // Ratings returns the list of ratings
 // responses:
 //   200: ratingsResponse

--- a/backend/e2etests/ratings.test.js
+++ b/backend/e2etests/ratings.test.js
@@ -16,7 +16,7 @@ describe(`${endpoint}`, function () {
         .expect("Content-Type", "application/json; charset=utf-8")
         .then((res) => {
           expect(JSON.stringify(res.body[0])).equal(
-            '{"salary_id":1,"company_id":994,"company_rating_id":569,"rating":2,"salary":1624669,"company_name":"Realbridge","seniority":"Seniority","comment":"Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.","job_title":"Recruiting Manager","country":"Country","city":"Livefish"}'
+            '{"salary_id":1,"company_id":994,"company_rating_id":569,"rating":2,"salary":1624669,"company_name":"Realbridge","seniority":"Seniority","comment":"Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.","job_title":"Recruiting Manager","country":"Country","city":"Livefish","createdat":"0001-01-01T00:00:00Z"}'
           );
         });
     });
@@ -28,7 +28,7 @@ describe(`${endpoint}`, function () {
         .expect(200)
         .expect("content-type", "application/json; charset=utf-8")
         .then((res) => {
-          expect(JSON.stringify(res.body)).to.equal('{"salary_id":1,"company_id":994,"company_rating_id":569,"rating":2,"salary":1624669,"company_name":"Realbridge","seniority":"Seniority","comment":"Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.","job_title":"Recruiting Manager","country":"Country","city":"Livefish"}');
+          expect(JSON.stringify(res.body)).to.equal('{"salary_id":1,"company_id":994,"company_rating_id":569,"rating":2,"salary":1624669,"company_name":"Realbridge","seniority":"Seniority","comment":"Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.","job_title":"Recruiting Manager","country":"Country","city":"Livefish","createdat":"0001-01-01T00:00:00Z"}');
         });
     });
 

--- a/backend/internal/storage/ratings.go
+++ b/backend/internal/storage/ratings.go
@@ -21,7 +21,8 @@ func (db DB) queryRatings() *gorm.DB {
 		c.name as company_name,
 		r.id as company_rating_id,
 		r.comment,
-		r.rating`).
+		r.rating,
+		r.createdat`).
 		Joins("LEFT JOIN companies c ON s.company_id = c.id").
 		Joins("LEFT JOIN company_ratings r ON s.company_rating_id = r.id")
 }

--- a/backend/pkg/models/v1beta/ratings.go
+++ b/backend/pkg/models/v1beta/ratings.go
@@ -1,5 +1,7 @@
 package v1beta
 
+import "time"
+
 //RatingQuery is a Rating query structure
 type RatingQuery struct {
 	ID int64 `form:"rating_id"`
@@ -8,17 +10,18 @@ type RatingQuery struct {
 //Rating defines the rating structure
 //This structure combines a salary and a company rating entry
 type Rating struct {
-	SalaryID        int64  `json:"salary_id" gorm:"column:salary_id"`
-	CompanyID       int64  `json:"company_id" gorm:"column:company_id"`
-	CompanyRatingID int64  `json:"company_rating_id" gorm:"column:company_rating_id"`
-	Rating          int64  `json:"rating" gorm:"column:rating"`
-	Salary          int64  `json:"salary" gorm:"column:salary"`
-	CompanyName     string `json:"company_name" gorm:"column:company_name"`
-	Seniority       string `json:"seniority" gorm:"column:seniority"`
-	Comment         string `json:"comment" gorm:"column:comment"`
-	JobTitle        string `json:"job_title" gorm:"column:job_title"`
-	Country         string `json:"country" gorm:"column:country"`
-	City            string `json:"city" gorm:"column:city"`
+	SalaryID        int64     `json:"salary_id" gorm:"column:salary_id"`
+	CompanyID       int64     `json:"company_id" gorm:"column:company_id"`
+	CompanyRatingID int64     `json:"company_rating_id" gorm:"column:company_rating_id"`
+	Rating          int64     `json:"rating" gorm:"column:rating"`
+	Salary          int64     `json:"salary" gorm:"column:salary"`
+	CompanyName     string    `json:"company_name" gorm:"column:company_name"`
+	Seniority       string    `json:"seniority" gorm:"column:seniority"`
+	Comment         string    `json:"comment" gorm:"column:comment"`
+	JobTitle        string    `json:"job_title" gorm:"column:job_title"`
+	Country         string    `json:"country" gorm:"column:country"`
+	City            string    `json:"city" gorm:"column:city"`
+	CreatedAt       time.Time `json:"createdat" gorm:"column:createdat"`
 }
 
 //AverageRating defines the average rating structure

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -255,7 +255,7 @@ paths:
           $ref: '#/responses/notFoundResponse'
       tags:
       - ratings
-  /ratings/{id}:
+  /ratings/{salaryID}:
     get:
       description: Ratings returns the list of ratings
       operationId: idOfRating

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -64,6 +64,10 @@ definitions:
       country:
         type: string
         x-go-name: Country
+      createdat:
+        format: date-time
+        type: string
+        x-go-name: CreatedAt
       job_title:
         type: string
         x-go-name: JobTitle


### PR DESCRIPTION
This pull request add a `createdAt` field to the `/ratings` `GET` endpoint response list

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-postrges` to run an initialized database
- run  `make run` to launch the api
- then run the command `curl -X GET localhost:7000/ratings` you should see something like this

```
[
{"salary_id":1,"company_id":994,"company_rating_id":569,"rating":2,"salary":1624669,"company_name":"Realbridge","seniority":"Seniority","comment":"Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.","job_title":"Recruiting Manager","country":"Country","city":"Livefish","createdat":"0001-01-01T00:00:00Z"},
...
]
```

also run `curl -X GET localhost:7000/ratings/1` you should see something like this
```
{"salary_id":1,"company_id":994,"company_rating_id":569,"rating":2,"salary":1624669,"company_name":"Realbridge","seniority":"Seniority","comment":"Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.","job_title":"Recruiting Manager","country":"Country","city":"Livefish","createdat":"0001-01-01T00:00:00Z"}
```