### PR TITLE
Add pagination ratings endpoints

### DIFF
--- a/backend/docs/ratings.go
+++ b/backend/docs/ratings.go
@@ -18,7 +18,7 @@ import (
 //   400: badRequestResponse
 //   404: notFoundResponse
 
-// swagger:route GET /average-rating ratings idOfRatingWithoutID
+// swagger:route GET /average-rating ratings
 // Ratings returns the list of ratings
 // responses:
 //   200: averageRatingResponse
@@ -29,14 +29,14 @@ import (
 // swagger:response ratingsResponse
 type RatingsResponseWrapper struct {
 	// in:body
-	Body []v1beta.Rating
+	Body v1beta.RatingResponse
 }
 
 // This text will appear as description of your response body.
 // swagger:response averageRatingResponse
 type AverageRatingResponseWrapper struct {
 	// in:body
-	Body []v1beta.AverageRating
+	Body v1beta.AverageRating
 }
 
 // swagger:response badRequestResponse
@@ -62,4 +62,15 @@ type RatingParam struct {
 	//in:path
 	//example: 1
 	ID string `json:"id"`
+}
+
+// swagger:parameters idOfRatingWithoutID
+type RatingsParam struct {
+	//in:query
+	//example: 1
+	Page string `json:"page"`
+
+	//in:query
+	//example: 20
+	Limit string `json:"limit"`
 }

--- a/backend/e2etests/ratings.test.js
+++ b/backend/e2etests/ratings.test.js
@@ -8,16 +8,29 @@ const endpoint = "ratings";
 
 describe(`${endpoint}`, function () {
   describe("GET", function () {
-    it("return a list of ratings", async function () {
+    it("return a list of ratings with page=1 & limit=2", async function () {
       return request(apiHost)
-        .get(endpoint)
+        .get(`${endpoint}?page=1&limit=2`)
         .send()
         .expect(200)
         .expect("Content-Type", "application/json; charset=utf-8")
         .then((res) => {
-          expect(JSON.stringify(res.body[0])).equal(
-            '{"salary_id":1,"company_id":994,"company_rating_id":569,"rating":2,"salary":1624669,"company_name":"Realbridge","seniority":"Seniority","comment":"Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.","job_title":"Recruiting Manager","country":"Country","city":"Livefish","createdat":"0001-01-01T00:00:00Z"}'
-          );
+          const body = JSON.stringify(res.body)
+          expect(body).contains('"hits":');
+          expect(body).contains('"limit":2,"nbHits":1000,"offset":0');
+        });
+    });
+
+    it("return a list of ratings with page=3", async function () {
+      return request(apiHost)
+        .get(`${endpoint}?page=3`)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          const body = JSON.stringify(res.body)
+          expect(body).contains('"hits":');
+          expect(body).contains(',"limit":20,"nbHits":1000,"offset":40}');
         });
     });
 

--- a/backend/internal/handlers/ratings_handler.go
+++ b/backend/internal/handlers/ratings_handler.go
@@ -20,7 +20,11 @@ func GetRatings(c *gin.Context) {
 		return
 	}
 
-	ratings, err := db.GetRatings()
+	//Get parameters
+	page := c.DefaultQuery("page", "1")
+	limit := c.DefaultQuery("limit", "20")
+
+	ratings, err := db.GetRatings(page, limit)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusInternalServerError,

--- a/backend/internal/storage/ratings.go
+++ b/backend/internal/storage/ratings.go
@@ -46,7 +46,6 @@ func (db DB) queryRatings() *gorm.DB {
 
 //GetRatings get ratings
 func (db DB) GetRatings(page, limit string) (v1beta.RatingResponse, error) {
-
 	offset, limitInt := Paginate(page, limit)
 	var nbHits int64
 	rows, err := db.queryRatings().Order("salary_id").Count(&nbHits).Offset(offset).Limit(limitInt).Rows()

--- a/backend/pkg/models/v1beta/ratings.go
+++ b/backend/pkg/models/v1beta/ratings.go
@@ -24,6 +24,13 @@ type Rating struct {
 	CreatedAt       time.Time `json:"createdat" gorm:"column:createdat"`
 }
 
+type RatingResponse struct {
+	Hits   []Rating `json:"hits"`
+	Limit  int64    `json:"limit"`
+	NBHits int64    `json:"nbHits"`
+	Offset int64    `json:"offset"`
+}
+
 //AverageRating defines the average rating structure
 type AverageRating struct {
 	Rating int64 `json:"rating" gorm:"column:rating"`

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -88,6 +88,27 @@ definitions:
         x-go-name: Seniority
     type: object
     x-go-package: github.com/elhmn/camerdevs/pkg/models/v1beta
+  RatingResponse:
+    properties:
+      hits:
+        items:
+          $ref: '#/definitions/Rating'
+        type: array
+        x-go-name: Hits
+      limit:
+        format: int64
+        type: integer
+        x-go-name: Limit
+      nbHits:
+        format: int64
+        type: integer
+        x-go-name: NBHits
+      offset:
+        format: int64
+        type: integer
+        x-go-name: Offset
+    type: object
+    x-go-package: github.com/elhmn/camerdevs/pkg/models/v1beta
   Salary:
     description: Salary defines the salary structure
     properties:
@@ -141,7 +162,7 @@ paths:
   /average-rating:
     get:
       description: Ratings returns the list of ratings
-      operationId: idOfRatingWithoutID
+      operationId: ratings
       responses:
         "200":
           $ref: '#/responses/averageRatingResponse'
@@ -149,8 +170,6 @@ paths:
           $ref: '#/responses/badRequestResponse'
         "404":
           $ref: '#/responses/notFoundResponse'
-      tags:
-      - ratings
   /companies:
     get:
       description: Companies returns the list of companies
@@ -250,6 +269,17 @@ paths:
     get:
       description: Ratings returns the list of ratings
       operationId: idOfRatingWithoutID
+      parameters:
+      - example: "1"
+        in: query
+        name: page
+        type: string
+        x-go-name: Page
+      - example: "20"
+        in: query
+        name: limit
+        type: string
+        x-go-name: Limit
       responses:
         "200":
           $ref: '#/responses/ratingsResponse'
@@ -327,9 +357,7 @@ responses:
   averageRatingResponse:
     description: This text will appear as description of your response body.
     schema:
-      items:
-        $ref: '#/definitions/AverageRating'
-      type: array
+      $ref: '#/definitions/AverageRating'
   badRequestResponse:
     description: ""
     schema:
@@ -378,9 +406,7 @@ responses:
   ratingsResponse:
     description: This text will appear as description of your response body.
     schema:
-      items:
-        $ref: '#/definitions/Rating'
-      type: array
+      $ref: '#/definitions/RatingResponse'
   salariesResponse:
     description: This text will appear as description of your response body.
     schema:


### PR DESCRIPTION
This pull request implement pagination for the GET `ratings?page=<page_number>&limit=<limit>` endpoint response list

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-postrges` to run an initialized database
- run  `make run` to launch the api
- then run the command `curl -X GET localhost:7000/ratings?page=3&limit=20` you should see something like this

```
{
  "hits": [
    {
      "salary_id": 41,
      "company_id": 949,
      "company_rating_id": 747,
      "rating": 2,
      "salary": 636974,
      "company_name": "Vimbo",
      "seniority": "Seniority",
      "comment": "Nullam sit amet turpis elementum ligula vehicula consequat. Morbi a ipsum. Integer a nibh.",
      "job_title": "Safety Technician I",
      "country": "Country",
      "city": "Feednation",
      "createdat": "0001-01-01T00:00:00Z"
    },
  ...
  ],
  "limit": 20,
  "nbHits": 1000,
  "offset": 40
}
```