### PR TITLE
Implement filters

### DIFF
--- a/backend/e2etests/ratings.test.js
+++ b/backend/e2etests/ratings.test.js
@@ -34,6 +34,45 @@ describe(`${endpoint}`, function () {
         });
     });
 
+    it("return a list of ratings with jobtitle=Recruiting Manager", async function () {
+      return request(apiHost)
+        .get(`${endpoint}?jobtitle=Recruiting Manager`)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          const body = JSON.stringify(res.body)
+          expect(body).contains('"hits":');
+          expect(body).contains('"limit":20,"nbHits":10,"offset":0');
+        });
+    });
+
+    it("return a list of ratings with company=Realbridge and jobtitle=Recruiting Manager", async function () {
+      return request(apiHost)
+        .get(`${endpoint}?company=Realbridge&jobtitle=Recruiting Manager`)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          const body = JSON.stringify(res.body)
+          expect(body).contains('"hits":');
+          expect(body).contains('"limit":20,"nbHits":1,"offset":0');
+        });
+    });
+
+    it("return a list of ratings with company=Realbridge", async function () {
+      return request(apiHost)
+        .get(`${endpoint}?company=Realbridge`)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          const body = JSON.stringify(res.body)
+          expect(body).contains('"hits":');
+          expect(body).contains('"limit":20,"nbHits":5,"offset":0');
+        });
+    });
+
     it("return a rating of id == 1", async function () {
       return request(apiHost)
         .get(`${endpoint}/1`)

--- a/backend/internal/handlers/ratings_handler.go
+++ b/backend/internal/handlers/ratings_handler.go
@@ -23,8 +23,10 @@ func GetRatings(c *gin.Context) {
 	//Get parameters
 	page := c.DefaultQuery("page", "1")
 	limit := c.DefaultQuery("limit", "20")
+	jobtitle := c.Query("jobtitle")
+	company := c.Query("company")
 
-	ratings, err := db.GetRatings(page, limit)
+	ratings, err := db.GetRatings(page, limit, jobtitle, company)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusInternalServerError,

--- a/backend/internal/storage/ratings.go
+++ b/backend/internal/storage/ratings.go
@@ -45,10 +45,19 @@ func (db DB) queryRatings() *gorm.DB {
 }
 
 //GetRatings get ratings
-func (db DB) GetRatings(page, limit string) (v1beta.RatingResponse, error) {
+func (db DB) GetRatings(page, limit, jobtitle, company string) (v1beta.RatingResponse, error) {
 	offset, limitInt := Paginate(page, limit)
 	var nbHits int64
-	rows, err := db.queryRatings().Order("salary_id").Count(&nbHits).Offset(offset).Limit(limitInt).Rows()
+
+	query := db.queryRatings().Order("salary_id")
+	if company != "" {
+		query = query.Where("c.name = ?", company)
+	}
+	if jobtitle != "" {
+		query = query.Where("s.title = ?", jobtitle)
+	}
+
+	rows, err := query.Count(&nbHits).Offset(offset).Limit(limitInt).Rows()
 	if err != nil {
 		return v1beta.RatingResponse{}, err
 	}


### PR DESCRIPTION
This pull request implement filters for the GET `ratings?company=<company_name>&jobtitle=<job_title>` endpoint response list

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-postrges` to run an initialized database
- run  `make run` to launch the api
- then run the command `curl -X GET localhost:7000/ratings?jobtitle=Recruiting%20Manager` you should see something like this

```
{
  "hits": [
    {
      "salary_id": 1,
      "company_id": 994,
      "company_rating_id": 569,
      "rating": 2,
      "salary": 1624669,
      "company_name": "Realbridge",
      "seniority": "Seniority",
      "comment": "Mauris enim leo, rhoncus sed, vestibulum sit amet, cursus id, turpis. Integer aliquet, massa id lobortis convallis, tortor risus dapibus augue, vel accumsan tellus nisi eu orci. Mauris lacinia sapien quis libero.",
      "job_title": "Recruiting Manager",
      "country": "Country",
      "city": "Livefish",
      "createdat": "0001-01-01T00:00:00Z"
    },
    ...
     ],
  "limit": 20,
  "nbHits": 10,
  "offset": 0
}
```