### PR TITLE
Compute average ratings with filters

### DIFF
--- a/backend/docs/ratings.go
+++ b/backend/docs/ratings.go
@@ -18,7 +18,7 @@ import (
 //   400: badRequestResponse
 //   404: notFoundResponse
 
-// swagger:route GET /average-rating ratings
+// swagger:route GET /average-rating ratings idOfAverageRating
 // Ratings returns the list of ratings
 // responses:
 //   200: averageRatingResponse
@@ -74,6 +74,17 @@ type RatingsParam struct {
 	//example: 20
 	Limit string `json:"limit"`
 
+	//in:query
+	//example: Realbridge
+	Company string `json:"company"`
+
+	//in:query
+	//example: Recruiting Manager
+	JobTitle string `json:"jobtitle"`
+}
+
+// swagger:parameters idOfAverageRating
+type AverageRatingParam struct {
 	//in:query
 	//example: Realbridge
 	Company string `json:"company"`

--- a/backend/docs/ratings.go
+++ b/backend/docs/ratings.go
@@ -73,4 +73,12 @@ type RatingsParam struct {
 	//in:query
 	//example: 20
 	Limit string `json:"limit"`
+
+	//in:query
+	//example: Realbridge
+	Company string `json:"company"`
+
+	//in:query
+	//example: Recruiting Manager
+	JobTitle string `json:"jobtitle"`
 }

--- a/backend/e2etests/ratings.test.js
+++ b/backend/e2etests/ratings.test.js
@@ -113,5 +113,45 @@ describe(`${endpoint2}`, function () {
           );
         });
     });
+
+    it("return a list of ratings with jobtitle=Recruiting Manager", async function () {
+      return request(apiHost)
+        .get(`${endpoint2}?jobtitle=Recruiting Manager`)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          expect(JSON.stringify(res.body)).equal(
+            '{"rating":4,"salary":2464858}'
+          );
+        });
+    });
+
+    it("return a list of ratings with company=Realbridge", async function () {
+      return request(apiHost)
+        .get(`${endpoint2}?company=Realbridge`)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          expect(JSON.stringify(res.body)).equal(
+            '{"rating":3,"salary":1954815}'
+          );
+        });
+    });
+
+    it("return a list of ratings with company=Realbridge and jobtitle=Recruiting Manager", async function () {
+      return request(apiHost)
+        .get(`${endpoint2}?company=Realbridge&jobtitle=Recruiting Manager`)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          expect(JSON.stringify(res.body)).equal(
+            '{"rating":2,"salary":1624669}'
+          );
+        });
+    });
+
   });
 });

--- a/backend/internal/handlers/ratings_handler.go
+++ b/backend/internal/handlers/ratings_handler.go
@@ -79,7 +79,11 @@ func GetAverageRating(c *gin.Context) {
 		return
 	}
 
-	rating, err := db.GetAverageRating()
+	//Get parameters
+	jobtitle := c.Query("jobtitle")
+	company := c.Query("company")
+
+	rating, err := db.GetAverageRating(jobtitle, company)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusInternalServerError,

--- a/backend/internal/storage/ratings.go
+++ b/backend/internal/storage/ratings.go
@@ -98,13 +98,21 @@ func (db DB) GetRatingByID(id int64) (v1beta.Rating, error) {
 }
 
 //GetAverageRating get average rating
-func (db DB) GetAverageRating() (v1beta.AverageRating, error) {
+func (db DB) GetAverageRating(jobtitle string, company string) (v1beta.AverageRating, error) {
 	r := struct {
 		AVGRating string `gorm:"column:rating"`
 		AVGSalary string `gorm:"column:salary"`
 	}{}
 
-	ret := db.queryRatings().Select("AVG(s.salary) as salary, AVG(r.rating) as rating").Find(&r)
+	query := db.queryRatings()
+	if company != "" {
+		query = query.Where("c.name = ?", company)
+	}
+	if jobtitle != "" {
+		query = query.Where("s.title = ?", jobtitle)
+	}
+
+	ret := query.Select("AVG(s.salary) as salary, AVG(r.rating) as rating").Find(&r)
 	if ret.Error != nil {
 		return v1beta.AverageRating{}, ret.Error
 	}

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -280,6 +280,16 @@ paths:
         name: limit
         type: string
         x-go-name: Limit
+      - example: Realbridge
+        in: query
+        name: company
+        type: string
+        x-go-name: Company
+      - example: Recruiting Manager
+        in: query
+        name: jobtitle
+        type: string
+        x-go-name: JobTitle
       responses:
         "200":
           $ref: '#/responses/ratingsResponse'

--- a/backend/swagger.yaml
+++ b/backend/swagger.yaml
@@ -162,7 +162,18 @@ paths:
   /average-rating:
     get:
       description: Ratings returns the list of ratings
-      operationId: ratings
+      operationId: idOfAverageRating
+      parameters:
+      - example: Realbridge
+        in: query
+        name: company
+        type: string
+        x-go-name: Company
+      - example: Recruiting Manager
+        in: query
+        name: jobtitle
+        type: string
+        x-go-name: JobTitle
       responses:
         "200":
           $ref: '#/responses/averageRatingResponse'
@@ -170,6 +181,8 @@ paths:
           $ref: '#/responses/badRequestResponse'
         "404":
           $ref: '#/responses/notFoundResponse'
+      tags:
+      - ratings
   /companies:
     get:
       description: Companies returns the list of companies


### PR DESCRIPTION
This pull request implements average rating with filters for the GET `average-rating?company=<company_name>&jobtitle=<job_title>` endpoint response list

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-postrges` to run an initialized database
- run  `make run` to launch the api
- then run the command `curl -X GET localhost:7000/average-rating?company=Realbridge&jobtitle=Recruiting%20Manager` you should see something like this

```
{"rating":2,"salary":1624669}
```