### PR TITLE
feat: adding a thousand separator on salaries

### DIFF
--- a/frontend/components/Average.vue
+++ b/frontend/components/Average.vue
@@ -39,7 +39,7 @@
             "
             style="font-family: 'Inter', sans-serif"
           >
-            {{ average }} FCFA
+            {{ average | price }}
           </p>
           <div class="flex pt-1 md:pt-0 ml-0 md:ml-24 md:mr-10">
             <div v-for="(item, index) in stars" :key="index" class="flex">

--- a/frontend/components/Company.vue
+++ b/frontend/components/Company.vue
@@ -152,7 +152,7 @@
                     class="text-xs md:text-sm text-gray-900"
                     style="color: #000000; font-family: 'Inter', sans-serif"
                   >
-                    {{ company.salary }} FCFA
+                    {{ company.salary | price }}
                   </div>
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -18,7 +18,9 @@ export default {
   css: [],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
-  plugins: [],
+  plugins: [
+    'plugins/filters.js'
+  ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,

--- a/frontend/plugins/filters.js
+++ b/frontend/plugins/filters.js
@@ -1,0 +1,5 @@
+import Vue from "vue"
+
+Vue.filter('price', (value) => {
+  return value.toString().replace(/(?<=\d)(?=(\d{3})+(?!\d))/g, ',') + " FCFA"
+})


### PR DESCRIPTION
This pull request is for adding thousand separator on salaries like mentioned in issue #107

Why ?
To make salaries more readable.

How ?
Just by separating thousands by a comma.

Steps to verify:
Just by checking the screenshots below :
![image](https://user-images.githubusercontent.com/36268779/155812473-bbf1029e-f8a8-431d-9cb2-c7bef2ce40f5.png)
![image](https://user-images.githubusercontent.com/36268779/155812552-96abfdf5-25d4-4d31-8ec8-27b226ce5ff0.png)
