### PR TITLE
refactor: remove regex from thousands separator filter

### DIFF
--- a/frontend/plugins/filters.js
+++ b/frontend/plugins/filters.js
@@ -1,5 +1,5 @@
 import Vue from "vue"
 
 Vue.filter('price', (value) => {
-  return value.toString().replace(/(?<=\d)(?=(\d{3})+(?!\d))/g, ',') + " FCFA"
+  return new Intl.NumberFormat('fr-CM', {style: 'currency', currency: 'XAF'}).format(value);
 })


### PR DESCRIPTION
This pull request removes the regular expression from the thousands separator filter (see #119).

Why ?
Because regex have unpredictable side effects

How ?
Using the native `Intl.NumberFormat`.

Steps to verify:
Check the Salaries table, column Salary.

** Screenshots (optional)
<img width="1298" alt="Screenshot 2022-02-27 at 22 08 51" src="https://user-images.githubusercontent.com/5704817/155900031-cfda5a01-7dd8-40f7-bff0-77c6c09e8fa9.png">
