### PR TITLE
TypoOnTheSubTitle: put the word rating in the plural

### DIFF
--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -4,7 +4,7 @@
       <div class="container mx-auto w-10/12">
         <Title
           title="100% Anonymous"
-          subTitle="Company rating and salaries in Cameroon"
+          subTitle="Company ratings and salaries in Cameroon"
           fontSize="header"
         />
         <div


### PR DESCRIPTION
![cstt](https://user-images.githubusercontent.com/34966088/155932362-c6a654f6-cefd-41ef-be82-1157d07084d9.png)
