### PR TITLE
Add default values to the get companies and endpoint

### DIFF
--- a/backend/e2etests/companies.test.js
+++ b/backend/e2etests/companies.test.js
@@ -16,8 +16,19 @@ describe(`${endpoint}`, function () {
         .expect("Content-Type", "application/json; charset=utf-8")
         .then((res) => {
           expect(JSON.stringify(res.body[0])).equal(
-            '{"id":72,"name":"Aibox","rating":2,"createdat":"0001-01-01T00:00:00Z","updatedat":"0001-01-01T00:00:00Z"}'
+            '{"id":102,"name":"ADC","rating":0,"createdat":"2022-04-06T00:00:00Z","updatedat":"2022-04-06T00:00:00Z"}'
           );
+        });
+    });
+
+    it("return a list of companies with default cameroonian companies", async function () {
+      return request(apiHost)
+        .get(endpoint)
+        .send()
+        .expect(200)
+        .expect("Content-Type", "application/json; charset=utf-8")
+        .then((res) => {
+          expect(JSON.stringify(res.body)).contains("Fonds national");
         });
     });
   });

--- a/backend/internal/storage/companies.go
+++ b/backend/internal/storage/companies.go
@@ -1,6 +1,8 @@
 package storage
 
-import "github.com/elhmn/camerdevs/pkg/models/v1beta"
+import (
+	"github.com/elhmn/camerdevs/pkg/models/v1beta"
+)
 
 //GetCompanies get companies
 func (db DB) GetCompanies() ([]v1beta.Company, error) {
@@ -8,6 +10,32 @@ func (db DB) GetCompanies() ([]v1beta.Company, error) {
 	ret := db.c.Table("companies").Order("name").Find(&companies)
 	if ret.Error != nil {
 		return companies, ret.Error
+	}
+
+	//Check if the first cameroonian company already exists
+	cameroonianCompany := v1beta.Company{}
+	ret = db.c.Table("companies").Where("name = ?", CameroonianCompanies[0]).Find(&cameroonianCompany)
+	if ret.Error != nil {
+		return companies, ret.Error
+	}
+
+	//If we did not find the first cameroonian company, we create every cameroonian companies
+	if cameroonianCompany.Name == "" {
+		for _, c := range CameroonianCompanies {
+			company := v1beta.Company{
+				Name: c,
+			}
+			ret := db.c.Create(&company)
+			if ret.Error != nil {
+				return companies, ret.Error
+			}
+		}
+
+		//Get the list of companies again
+		ret := db.c.Table("companies").Order("name").Find(&companies)
+		if ret.Error != nil {
+			return companies, ret.Error
+		}
 	}
 
 	return companies, nil
@@ -22,4 +50,186 @@ func (db DB) GetCompanyByID(id int64) (v1beta.Company, error) {
 	}
 
 	return company, nil
+}
+
+//CameroonianCompanies is collection of default cameroonian companies
+var CameroonianCompanies = []string{
+	"CCAA",
+	"ADC",
+	"ADER",
+	"Alpicam Industries",
+	"Alucam",
+	"AMPCI",
+	"Aberec Limited Machines électriques et matériels électroniques",
+	"Afriland First Bank",
+	"AFRILANE",
+	"AFROLOGIX",
+	"AFOUP",
+	"ANAFOR",
+	"ASMAP",
+	"AT graphiline",
+	"AFROSPHINX",
+	"APN",
+	"Brasseries du Cameroun",
+	"Business Facilities Corporation S.A",
+	"BT ROUTES S.A",
+	"BICEC",
+	"B.E.S Best Engineering System Sarl",
+	"Boh Plantations Limited",
+	"BUNS Sarl",
+	"BYOOS sarl",
+	"Bendo sarl",
+	"BVS",
+	"Camair",
+	"Camair-Co",
+	"Cambuild-BTP",
+	"Camdev emploi et formation",
+	"Camerinside Web Agency",
+	"Camerounaise des Eaux",
+	"Cameroon Water Utilities Corporation",
+	"Cameroon Development Corporation",
+	"Camercrack",
+	"Camlait",
+	"Campost",
+	"Camtel",
+	"Camrail",
+	"Cameroon Chemical Company",
+	"Cameroon Development Corporation",
+	"Cameroon Tea Estates",
+	"CamerPages",
+	"CAWAD",
+	"CCAA",
+	"CCPC Finance",
+	"Chanas assurances",
+	"Chantier naval industriel du Cameroun",
+	"CICAM",
+	"Clarans Afrique",
+	"Crédit lyonnais du Cameroun",
+	"Cimenterie du Cameroun",
+	"Crédit Foncier du Cameroun",
+	"CNIC",
+	"Commercial Bank of Cameroon",
+	"Compagnie d'Opérations Pétrolières Schlumberger",
+	"Conseil National des Chargeurs du Cameroun",
+	"Coordonnerie du 3e Millénaire",
+	"CRTV",
+	"CONGELCAM",
+	"Corlay Cameroun",
+	"CCA",
+	"CDS",
+	"CA Integrated Systems & consulting",
+	"CNPS",
+	"Douala Stock Exchange",
+	"DIPMAN",
+	"DANAY EXPRESS",
+	"DIGIT CAMEROON",
+	"EBA GROUP",
+	"E-Business Cameroon SARL",
+	"Electricity Development Corporation",
+	"Express Union",
+	"EIF-CONSULTING AND SERVICES SARL",
+	"Enéo Cameroon",
+	"EVA Corporation SARL",
+	"EWONGA SARL",
+	"ETS KOT SUD DOUALA",
+	"FRINT GROUP",
+	"Fonds national de l'emploi",
+	"Foongon Corporation",
+	"FEICOM",
+	"FB-Building",
+	"GSEC",
+	"Gaz du Cameroun",
+	"Geovic Cameroon",
+	"GETRACOM-INTER",
+	"GEQUIPS",
+	"GFBC",
+	"Guinness Cameroun sa",
+	"GNO Solutions",
+	"GESSIIA SARL",
+	"Haltech",
+	"Hévécam",
+	"Hope Management & Consulting",
+	"Hope Music Group",
+	"Hope Music Publishing",
+	"HSC Cameroun",
+	"IFATI",
+	"ITGStore",
+	"ICCSOFT",
+	"IMS",
+	"INSTRUMELEC",
+	"INSURMIND TECH",
+	"IELT CAMEROUN",
+	"IFRIQUIYA Conseil Sarl",
+	"Joy Bonapriso",
+	"KEN Technology Sarl",
+	"KPMG",
+	"KIMPA SAS",
+	"LANAVET",
+	"LIGHTECH",
+	"LAPIN237",
+	"LOCAGRUES CAMEROUN",
+	"LUMEN SARL",
+	"MIDEPECAM",
+	"MTN Cameroun",
+	"MIRE WORLD",
+	"Megasoft",
+	"Maguysama Technologies Solaires",
+	"MY WAY Sarl",
+	"Mezadi SARL",
+	"MEN TRAVEL",
+	"NACYDATE",
+	"Ndawara Tea Estates",
+	"Nestlé Cameroun",
+	"Nexttel cameroun",
+	"NTARRA",
+	"Nexa Industries",
+	"Orange Cameroun",
+	"Ok Plast Cam",
+	"Opticam",
+	"PERFITCOM",
+	"Plantations Pamol du Cameroun",
+	"PHP",
+	"Philjohn Technologies",
+	"PMUC",
+	"Port autonome de Douala",
+	"Port autonome de Kribi",
+	"Port autonome de Limbé",
+	"Plasticam",
+	"Pro Services Emploi",
+	"Projects Experts Consulting",
+	"Prosygma Cameroun",
+	"PwC Cameroun",
+	"Quezil Language Services traduction",
+	"ETS RIVER",
+	"SABC",
+	"SACONETS",
+	"SARMETAL",
+	"SBS Smart Business Solutions",
+	"SCDP",
+	"Semry",
+	"SGBC",
+	"SNH",
+	"Sodecoton",
+	"Socatral",
+	"Socapalm",
+	"SOCATUR",
+	"SONARA",
+	"Sopecam",
+	"SANCOMS",
+	"SOCOSER",
+	"SODEPA",
+	"SOTRACOM",
+	"SUDCAM",
+	"Secours auto",
+	"Societé Camerounaise d'équipement",
+	"SimaLap",
+	"SYSCOM SARL",
+	"S&P",
+	"Touristiques Express",
+	"Third",
+	"Tradex",
+	"The House of services",
+	"Uccao",
+	"UPTIMA.CM Sarl",
+	"WAT&CO",
 }


### PR DESCRIPTION
This pull request set default values for the `GET /companies` endpoint

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-api` to start the api
- then run the command `curl -X GET localhost:7000/companies | jq` you should see something like this

```
{
  "hits": [{
    "id": 102,
    "name": "ADC",
    "rating": 0,
    "createdat": "2022-04-06T00:00:00Z",
    "updatedat": "2022-04-06T00:00:00Z"
  },
  {
    "id": 103,
    "name": "ADER",
    "rating": 0,
    "createdat": "2022-04-06T00:00:00Z",
    "updatedat": "2022-04-06T00:00:00Z"
  },
  ...
  ],
  "limit": 20,
  "nbHits": 1000,
  "offset": 40
}
```
