### PR TITLE
feat(backend): set job title and city as mandatory fields for the rating POST request

### DIFF
--- a/backend/e2etests/ratings.test.after.js
+++ b/backend/e2etests/ratings.test.after.js
@@ -29,6 +29,46 @@ describe("POST", function () {
       .expect("Content-Type", "application/json; charset=utf-8");
   });
 
+  it("POST, fail to add a new rating entry without job_title", async function () {
+    return request(apiHost)
+      .post(`${endpoint}?page=1&limit=2`)
+      .set("Accept", "application/json")
+      .send({
+        company_name: "La Mater",
+        //we set the salary to zero to avoid breaking the average-ratings tests
+        //as the salary set -1 are not counted in the calculation of the average
+        salary: 0,
+        //we set the rating to zero to avoid breaking the average-ratings tests
+        //as the rating set -1 are not counted in the calculation of the average
+        rating: 0,
+        comment: "my comment",
+        seniority: "Seniority",
+        city: "Maroua",
+      })
+      .expect(400)
+      .expect("Content-Type", "application/json; charset=utf-8");
+  });
+
+  it("POST, fail to add a new rating entry without city", async function () {
+    return request(apiHost)
+      .post(`${endpoint}?page=1&limit=2`)
+      .set("Accept", "application/json")
+      .send({
+        company_name: "La Mater",
+        //we set the salary to zero to avoid breaking the average-ratings tests
+        //as the salary set -1 are not counted in the calculation of the average
+        salary: 0,
+        //we set the rating to zero to avoid breaking the average-ratings tests
+        //as the rating set -1 are not counted in the calculation of the average
+        rating: 0,
+        job_title: "a job_title",
+        comment: "my comment",
+        seniority: "Seniority",
+      })
+      .expect(400)
+      .expect("Content-Type", "application/json; charset=utf-8");
+  });
+
   it("POST add a new rating entry with lowercase cities, company_name, and jobtitle", async function () {
     const sendRequest = () =>
       request(apiHost)

--- a/backend/e2etests/ratings.test.after.js
+++ b/backend/e2etests/ratings.test.after.js
@@ -19,6 +19,7 @@ describe("POST", function () {
         //we set the rating to zero to avoid breaking the average-ratings tests
         //as the rating set -1 are not counted in the calculation of the average
         rating: 0,
+        job_title: "a job_title",
         comment: "my comment",
         seniority: "Seniority",
         city: "Maroua",

--- a/backend/internal/handlers/ratings_handler.go
+++ b/backend/internal/handlers/ratings_handler.go
@@ -112,6 +112,15 @@ func PostRatings(c *gin.Context) {
 		log.Error(err)
 		c.JSON(http.StatusBadRequest,
 			gin.H{"error": "could not post rating"})
+		return
+	}
+
+	err := query.Validate()
+	if err != nil {
+		log.Error(err)
+		c.JSON(http.StatusBadRequest,
+			gin.H{"error": err.Error()})
+		return
 	}
 
 	//Initialize db client

--- a/backend/internal/handlers/ratings_handler.go
+++ b/backend/internal/handlers/ratings_handler.go
@@ -112,7 +112,6 @@ func PostRatings(c *gin.Context) {
 		log.Error(err)
 		c.JSON(http.StatusBadRequest,
 			gin.H{"error": "could not post rating"})
-		return
 	}
 
 	err := query.Validate()

--- a/backend/pkg/models/v1beta/ratings.go
+++ b/backend/pkg/models/v1beta/ratings.go
@@ -1,6 +1,10 @@
 package v1beta
 
-import "time"
+import (
+	"errors"
+	"strings"
+	"time"
+)
 
 //RatingQuery is a Rating query structure
 type RatingQuery struct {
@@ -47,4 +51,21 @@ type RatingPostQuery struct {
 	Comment     string `json:"comment"`
 	Seniority   string `json:"seniority"`
 	Rating      int64  `json:"rating"`
+}
+
+// Validate check if the mandatory fields are filled
+func (r RatingPostQuery) Validate() error {
+	if strings.TrimSpace(r.CompanyName) == "" {
+		return errors.New("company name is mandatory")
+	}
+
+	if strings.TrimSpace(r.JobTitle) == "" {
+		return errors.New("job title is mandatory")
+	}
+
+	if r.Rating <= 0 {
+		return errors.New("rating is mandatory")
+	}
+
+	return nil
 }

--- a/backend/pkg/models/v1beta/ratings.go
+++ b/backend/pkg/models/v1beta/ratings.go
@@ -55,16 +55,12 @@ type RatingPostQuery struct {
 
 // Validate check if the mandatory fields are filled
 func (r RatingPostQuery) Validate() error {
-	if strings.TrimSpace(r.CompanyName) == "" {
-		return errors.New("company name is mandatory")
-	}
-
 	if strings.TrimSpace(r.JobTitle) == "" {
 		return errors.New("job title is mandatory")
 	}
 
-	if r.Rating <= 0 {
-		return errors.New("rating is mandatory")
+	if strings.TrimSpace(r.City) == "" {
+		return errors.New("city is mandatory")
 	}
 
 	return nil


### PR DESCRIPTION
This pull request set Jobtitles and City as Mandatory fields for the rating POST request. Related to #202 

Steps to verify:

  - move to the backend folder with cd ./backend
  - run make start-postgres to run an initialized database
  - run make run to launch the api
  - then run the following commands

1️⃣ Check JobTitle
```shell 
curl -s -X POST 'http://localhost:7000/ratings' -H 'Content-Type: application/json' -d '{"city": "Douala","comment": "my comment","company_name": "OssCameroun","job_title": "","rating": 2,"salary": 1200,"seniority": "CV"}'
```

you should see something like this 👇

```
{"error":"job title is mandatory"}
```

2️⃣ Check City
```shell 
curl -s -X POST 'http://localhost:7000/ratings' -H 'Content-Type: application/json' -d '{"city": "","comment": "my comment","company_name": "OssCameroun","job_title": "Maintainer","rating": 2,"salary": 1200,"seniority": "CV"}'
```

you should see something like this 👇

```
{"error":"city is mandatory"}
```