### PR TITLE
feat: add seniority intern

### DIFF
--- a/backend/internal/handlers/seniority_handler.go
+++ b/backend/internal/handlers/seniority_handler.go
@@ -10,6 +10,7 @@ import (
 //GetSeniority returns a list of seniority levels
 func GetSeniority(c *gin.Context) {
 	seniority := []string{
+		v1beta.SeniorityIntern,
 		v1beta.SeniorityEntryLevel,
 		v1beta.SeniorityMidLevel,
 		v1beta.SenioritySenior,


### PR DESCRIPTION
Add `Intern` as a possible seniority

Steps to verify:
- move to the `backend` folder with `cd ./backend`
- run `make start-postgres` to run an initialized database
- run  `make run` to launch the api
- then run the command `curl -X GET localhost:7000/seniority` you should see something like this

```
["Intern","Entry-level","Mid-level","Senior","Above senior-level","Executive"]
```

