### PR TITLE
feat(backend): do not consider ratings == 0 , when calculating the average rating

### DIFF
--- a/backend/e2etests/ratings.test.js
+++ b/backend/e2etests/ratings.test.js
@@ -153,5 +153,41 @@ describe(`${endpoint2}`, function () {
         });
     });
 
+      it("add 2 rating entry for one company, one with rating set to 0 and another set to 5, the result should be 5 instead of 2", async function() {
+          const sendRequest = (rating) =>
+              request(apiHost)
+                  .post(`${endpoint}`)
+                  .set("Accept", "application/json")
+                  .send({
+                      company_name: "Oss",
+                      job_title: "technicien de surface",
+                      //we set the salary to zero to avoid breaking the average-ratings tests
+                      //as the salary set -1 are not counted in the calculation of the average
+                      salary: 0,
+                      //we set the rating to zero to avoid breaking the average-ratings tests
+                      //as the rating set -1 are not counted in the calculation of the average
+                      rating: rating,
+                      comment: "my comment",
+                      seniority: "Seniority",
+                      city: "maroua",
+                      //the country field is omitted here as we always set it to Cameroon for now
+                  })
+                  .expect(201)
+                  .expect("Content-Type", "application/json; charset=utf-8");
+
+          await sendRequest(0)
+          await sendRequest(5)
+
+          return request(apiHost)
+              .get(`${endpoint2}?company=Oss`)
+              .set("Accept", "application/json")
+              .send()
+              .expect(200)
+              .expect("Content-Type", "application/json; charset=utf-8")
+              .then((res) => {
+                  const averageRating = res.body.rating;
+                  expect(averageRating).equal(5);
+              });
+      });
   });
 });

--- a/backend/internal/storage/ratings.go
+++ b/backend/internal/storage/ratings.go
@@ -64,7 +64,7 @@ func (db DB) queryRatings() *gorm.DB {
                     Select count(ss.id)
                     from salaries ss
                     where ss.company_id = s.company_id
-						and ss.title_id = s.title_id) < 5 then 0
+						and ss.title_id = s.title_id) < 5 then NULL
            else r.rating end as rating
 		`).
 		Joins("LEFT JOIN companies c ON s.company_id = c.id").
@@ -140,9 +140,7 @@ func (db DB) GetAverageRating(jobtitle string, company string) (v1beta.AverageRa
 		query = query.Where("j.title = ?", jobtitle)
 	}
 
-	query = query.Where("r.rating <> 0")
-
-	ret := query.Select("AVG(s.salary) as salary, AVG(r.rating) as rating").Find(&r)
+	ret := query.Select("AVG(s.salary) as salary, AVG(NULLIF (r.rating, 0)) as rating").Find(&r)
 	if ret.Error != nil {
 		return v1beta.AverageRating{}, ret.Error
 	}

--- a/backend/internal/storage/ratings.go
+++ b/backend/internal/storage/ratings.go
@@ -140,6 +140,8 @@ func (db DB) GetAverageRating(jobtitle string, company string) (v1beta.AverageRa
 		query = query.Where("j.title = ?", jobtitle)
 	}
 
+	query = query.Where("r.rating <> 0")
+
 	ret := query.Select("AVG(s.salary) as salary, AVG(r.rating) as rating").Find(&r)
 	if ret.Error != nil {
 		return v1beta.AverageRating{}, ret.Error


### PR DESCRIPTION
This pull request do not consider ratings equal to 0 when calculating the average rating

### Step to verify
  - move to the backend folder with cd ./backend
  - run make start-postrges to run an initialized database
  - run make run to launch the api
  - 

1️⃣then run the command to create a ratings

```shell 
curl -s -X POST 'http://localhost:7000/ratings' -H 'Content-Type: application/json' -d '{"city": "Douala","comment": "my comment","company_name": "Oss","job_title": "Dev","rating": 2,"salary": 1200,"seniority": "CV"}'
```

2️⃣run the following command to get the average rating
```shell 
curl -s -X GET "http://localhost:7000/average-rating?company=Oss"
```
you should see something like this 👇

```json
{
    "rating": 2,
    "salary": 1200
}
```

3️⃣ now run this command x times to create company rating with rating == 0
```shell 
curl -s -X POST 'http://localhost:7000/ratings' -H 'Content-Type: application/json' -d '{"city": "Douala","comment": "my comment","company_name": "Oss","job_title": "Dev","rating": 0,"salary": 0,"seniority": "CV"}'
```

4️⃣ run the steps 2 the rating field in the output should be the same

