### PR TITLE
fix(backend): only show list of company with salary entries not between 1 and maxEntryBeforeDisplay-1

### DIFF
--- a/backend/e2etests/ratings.test.js
+++ b/backend/e2etests/ratings.test.js
@@ -191,11 +191,11 @@ describe(`${endpoint2}`, function () {
       });
 
     it("List only companies who hasn't salaries entries between 1 and maxEntryBeforeDisplay - 1", async function () {
-          return request(apiHost)
+        const sendRequest = () => request(apiHost)
               .post(endpoint)
               .set("Accept", "application/json")
               .send({
-                  company_name: "Not_max_entry",
+                  company_name: "Elhmnco",
                   //we set the salary to zero to avoid breaking the average-ratings tests
                   //as the salary set -1 are not counted in the calculation of the average
                   salary: 0,
@@ -208,17 +208,31 @@ describe(`${endpoint2}`, function () {
                   city: "Maroua",
               })
               .expect(201)
-              .expect("content-type", "application/json; charset=utf-8")
-              .then(async () => {
-                  return request(apiHost)
-                      .get("companies")
-                      .send()
-                      .expect(200)
-                      .expect("Content-Type", "application/json; charset=utf-8")
-                      .then((res) => {
-                          expect(JSON.stringify(res.body)).to.not.contains('"name":"Not_max_entry"');
-                      });
-              });
+              .expect("content-type", "application/json; charset=utf-8");
+
+        await sendRequest()
+
+        request(apiHost)
+            .get("companies")
+            .send()
+            .expect(200)
+            .expect("Content-Type", "application/json; charset=utf-8")
+            .then((res) => {
+                expect(JSON.stringify(res.body)).to.not.contains('"name":"Elhmnco"');
+            });
+
+        for (let i = 0; i < 3; i++) {
+            await sendRequest();
+        }
+
+        return request(apiHost)
+            .get("companies")
+            .send()
+            .expect(200)
+            .expect("Content-Type", "application/json; charset=utf-8")
+            .then((res) => {
+                expect(JSON.stringify(res.body)).contains('"name":"Elhmnco"');
+            });
       });
   });
 });

--- a/backend/e2etests/ratings.test.js
+++ b/backend/e2etests/ratings.test.js
@@ -189,5 +189,36 @@ describe(`${endpoint2}`, function () {
                   expect(averageRating).equal(5);
               });
       });
+
+    it("List only companies who hasn't salaries entries between 1 and maxEntryBeforeDisplay - 1", async function () {
+          return request(apiHost)
+              .post(endpoint)
+              .set("Accept", "application/json")
+              .send({
+                  company_name: "Not_max_entry",
+                  //we set the salary to zero to avoid breaking the average-ratings tests
+                  //as the salary set -1 are not counted in the calculation of the average
+                  salary: 0,
+                  //we set the rating to zero to avoid breaking the average-ratings tests
+                  //as the rating set -1 are not counted in the calculation of the average
+                  rating: 0,
+                  job_title: "A Job_title",
+                  comment: "my comment",
+                  seniority: "Seniority",
+                  city: "Maroua",
+              })
+              .expect(201)
+              .expect("content-type", "application/json; charset=utf-8")
+              .then(async () => {
+                  return request(apiHost)
+                      .get("companies")
+                      .send()
+                      .expect(200)
+                      .expect("Content-Type", "application/json; charset=utf-8")
+                      .then((res) => {
+                          expect(JSON.stringify(res.body)).to.not.contains('"name":"Not_max_entry"');
+                      });
+              });
+      });
   });
 });


### PR DESCRIPTION
This pull request does list only company with salary entries not between 1 and maxEntryBeforeDisplay-1.

Why ?
Because we need to not hide company if a we hasn't maxEntryBeforeDisplay entries. See #197 and this [comment ](https://github.com/osscameroon/camerdevs/issues/197#issuecomment-1107782063)

Steps to verify:
  - move to the backend folder with cd ./backend
  - run make start-postrges to run an initialized database
  - run make run to launch the api
  - then run the command

1️⃣Add a rating for a company
```shell 
curl -s -X POST 'http://localhost:7000/ratings' -H 'Content-Type: application/json' -d '{"city": "Douala","comment": "my comment","company_name": "Elhmnco","job_title": "Cleaner","rating": 2,"salary": 1200,"seniority": "CV"}'
```
you should see something like this 👇

```json
{"message":"created"}
```

2️⃣Get list of company
```shell 
curl  --silent -X GET https://api.jobsika.stage.osscameroon.com/companies | grep -q Elhmnco && echo "Fo
und" || echo "Not found"
```
you should see 👇

```
Not found
```

3️⃣Re-Execute the request on step one 3 times

4️⃣Get list of company
```shell 
curl  --silent -X GET https://api.jobsika.stage.osscameroon.com/companies | grep -q Elhmnco && echo "Fo
und" || echo "Not found"
```
you should see 👇

```
Found
```