### PR TITLE
feat: add seniority filter on Get Ratings

### DIFF
--- a/backend/e2etests/ratings.test.js
+++ b/backend/e2etests/ratings.test.js
@@ -106,6 +106,18 @@ describe(`${endpoint}`, function () {
                   expect(data.every(v => v.city === 'Maroua')).equal(true)
               });
       });
+
+      it("List ratings with seniority = Seniority", async function () {
+          return request(apiHost)
+              .get(`${endpoint}?seniority=seniority`)
+              .send()
+              .expect(200)
+              .expect("Content-Type", "application/json; charset=utf-8")
+              .then((res) => {
+                  const data = res.body.hits;
+                  expect(data.every(v => v.seniority === 'Seniority')).equal(true)
+              });
+      });
   });
 
 });

--- a/backend/internal/handlers/ratings_handler.go
+++ b/backend/internal/handlers/ratings_handler.go
@@ -29,8 +29,9 @@ func GetRatings(c *gin.Context) {
 	jobtitle := c.Query("jobtitle")
 	company := c.Query("company")
 	city := c.Query("city")
+	seniority := c.Query("seniority")
 
-	ratings, err := db.GetRatings(page, limit, jobtitle, company, city)
+	ratings, err := db.GetRatings(page, limit, jobtitle, company, city, seniority)
 	if err != nil {
 		log.Error(err)
 		c.JSON(http.StatusInternalServerError,

--- a/backend/internal/storage/ratings.go
+++ b/backend/internal/storage/ratings.go
@@ -79,7 +79,7 @@ func (db DB) queryRatings() *gorm.DB {
 }
 
 //GetRatings get ratings
-func (db DB) GetRatings(page, limit, jobtitle, company, city string) (v1beta.RatingResponse, error) {
+func (db DB) GetRatings(page, limit, jobtitle, company, city, seniority string) (v1beta.RatingResponse, error) {
 	offset, limitInt := Paginate(page, limit)
 	var nbHits int64
 
@@ -92,6 +92,9 @@ func (db DB) GetRatings(page, limit, jobtitle, company, city string) (v1beta.Rat
 	}
 	if city != "" {
 		query = query.Where("ct.name = ?", city)
+	}
+	if seniority != "" {
+		query = query.Where("s.seniority = ?", seniority)
 	}
 
 	rows, err := query.Count(&nbHits).Offset(offset).Limit(limitInt).Rows()


### PR DESCRIPTION
This pull request add seniority filter on Get Ratings

Steps to verify:

  - move to the backend folder with cd ./backend
  - run make start-postgres to run an initialized database
  - run make run to launch the api
  - then run the following commands

1️⃣ Get ratings of a city
```shell 
curl -X GET 'http://localhost:7000/ratings?page=1&limit=10&seniority=Seniority'
```

you should see every entry with seniority equal to Seniority
